### PR TITLE
Update cookie.debug.js, do not show if navigator.CookiesOK is set

### DIFF
--- a/cookie.debug.js
+++ b/cookie.debug.js
@@ -353,7 +353,7 @@
           document.getElementById('functional').checked = true;
           document.getElementById('strict').checked = true;
           document.getElementById('targeting').checked = false;
-        } else if (EU.Cookie.get(AppConfig.cookie) === '3') {
+        } else if (EU.Cookie.get(AppConfig.cookie) === '3' || navigator.CookiesOK) {
           listFeatures('targeting');
           document.getElementById('targeting').checked = true;
           document.getElementById('functional').checked = true;


### PR DESCRIPTION
If the user has installed CookiesOK to automatically accept all cookies navigator.CookiesOK will be set and this may be treated as a full consent
