### PR TITLE
Update cookie.debug.js

### DIFF
--- a/cookie.debug.js
+++ b/cookie.debug.js
@@ -489,7 +489,7 @@
     return {
       setup : function (options) {
         config = options;
-        if (!EU.Cookie.get(options.cookie_prefix + options.optin_cookie_name)) {
+        if (!EU.Cookie.get(options.cookie_prefix + options.optin_cookie_name) || navigator.CookiesOK) {
           if (options && !options.test) {
             createPanelUI();
           }


### PR DESCRIPTION
If navigator.CookiesOK is set, the user has installed browser extension 'CookiesOK' to automatically accept cookie warnings. By adding these lines any website using 'eu-cookie-opt-in' automatically is supported by CookiesOK.
